### PR TITLE
sql logic simplifier, with comment:variable beginning of line

### DIFF
--- a/lib/query-builder/index.js
+++ b/lib/query-builder/index.js
@@ -96,6 +96,45 @@ class QueryBuilder {
     }
 
     runQuery(sql, args) {
+
+        /*
+            sql logic simplification :
+            when used within LIKE statements for example, empty variables are useless,
+            and produced overweighted sql queries for nothing.
+
+            if a line starts with "#:variable ...." if "variable" will be an empty string, we will remove such line.
+
+            example :
+            args = { 'firstname': '', 'lastname': 'zzz' }
+            sql = """
+                SELECT * FROM table WHERE 1
+                #:firstname   AND firstname LIKE CONCAT('%', :firstname, '%')
+                #:lastname    AND lastname LIKE CONCAT('%', :lastname, '%')
+            """
+
+            the sql variable will be rewritten into
+            sql = """
+                SELECT * FROM table WHERE 1
+                #:firstname   AND firstname LIKE CONCAT('%', :firstname, '%')
+                    AND lastname LIKE CONCAT('%', :lastname, '%')
+            """
+            keeping comment on "#:firstname " line, and removing the comment on "#:lastname " line
+        */
+        var sqlLines = sql.match(/[^\r\n]+/g)
+        for (const line in [...sqlLines.keys()]) {
+            if (sqlLines[line].startsWith("#:")) {
+                try {
+                    var vargs = args[sqlLines[line].split(' ')[0].substring(2)]
+                    if (vargs !== "") {
+                        sqlLines[line] = sqlLines[line].substring(sqlLines[line].indexOf(' '))
+                    }
+                } catch (error) {
+                    this.logger.debug("commented variable misunderstood " + sqlLines[line])
+                }
+            }
+        }
+        sql = sqlLines.join('\n')
+        this.logger.debug(sql)
         return this.connection.raw(sql, args)
     }
 


### PR DESCRIPTION
When writing json payload services, empty variables can overweight your sql request, typically, if you use "LIKE" statements.
This patch proposes to comment line by line, the potentially useless sql fragments.

On a 3 millions record tables, on MySQL, with potentially 10 different parameters,
This change enhances x 2 time performances.